### PR TITLE
Override nixpkgs for stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,14 +60,14 @@ Then it needs to parse the hie files and recover any useful information.
 
 Build with:
 ```bash
-stack build izuna-builder --stack-yaml=stack-8.10.1.yaml
+stack build izuna-builder --stack-yaml=stack-8.10.1.yaml --no-nix
 ```
 
 izuna-server is a simple server that returns the processed hie files for the plugin.
 
 Build with:
 ```bash
-stack build izuna-server --stack-yaml=stack-8.10.1.yaml
+stack build izuna-server --stack-yaml=stack-8.10.1.yaml --no-nix
 ```
 
 ## Inspirations

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,0 +1,9 @@
+let
+  rev = "2c0f6135aab77ff942b615228882c7dd996e0882";
+  extractedTarball = fetchTarball {
+    url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
+    sha256 = "sha256:00yg8dck4ymcifrxsknnpms52n16xnb8yiqjkby002mbm2aflf45";
+  };
+in
+  # extractedTarball will be a directory here, and 'import' will automatically append /default.nix here
+import extractedTarball

--- a/stack-8.10.1.yaml
+++ b/stack-8.10.1.yaml
@@ -16,3 +16,4 @@ extra-deps:
 nix:
   enable: true
   packages: [ zlib ]
+  path: [nixpkgs=./nixpkgs.nix]

--- a/stack-8.10.2.yaml
+++ b/stack-8.10.2.yaml
@@ -9,3 +9,4 @@ extra-deps:
 nix:
   enable: true
   packages: [ zlib ]
+  path: [nixpkgs=./nixpkgs.nix]


### PR DESCRIPTION
This makes sure both ghc 8.10.1 and 8.10.2 are available for NixOS