### PR TITLE
fix tab switching bug

### DIFF
--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -1,33 +1,102 @@
 main();
 
-function main() {
-  chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
-    chrome.tabs.query({ currentWindow: true, active: true }, tabs => {
-      const pullRequestInfo = getPullRequestInfo(tabs);
-      fetchPullRequestCommitsDetails(pullRequestInfo).then(pullRequestDetails => {
-        const oldPackageInfo = fetchPackageInfo(pullRequestInfo, pullRequestDetails.targetOid);
-        const newPackageInfo = fetchPackageInfo(pullRequestInfo, pullRequestDetails.commitOids[0]);
+var cache = {};
 
-        Promise.all([oldPackageInfo, newPackageInfo])
-          .then(packageInfo => sendResponse(
-            {
-              oldPackageInfo: packageInfo[0],
-              newPackageInfo: packageInfo[1]
-            }
-          ));
+function main() {
+  chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+    const pathname = githubPullRequestUrlPathName(tabId, changeInfo, tab);
+    if(pathname) {
+      const pullRequestInfo = getPullRequestInfo(pathname);
+
+      fetchPullRequestCommitsDetails(pullRequestInfo).then(pullRequestDetails => {
+        getPackageInfo(pullRequestInfo, pullRequestDetails).then(packageInfo => {
+          storeInCache(pullRequestInfo, pullRequestDetails, packageInfo);
+          const payload = {
+            oldPackageInfo: packageInfo[0],
+            newPackageInfo: packageInfo[1]
+          }
+
+          chrome.tabs.sendMessage(tab.id, payload, (response) => {});
+        });
       });
-    });
-    return true;
-  });
+    }
+  })
+}
+
+function storeInCache(pullRequestInfo, pullRequestDetails, packageInfo) {
+  const cached = getInCache(pullRequestInfo, pullRequestDetails);
+  if(! cached) {
+    const now = Math.floor(Date.now() / 1000); // timestamp in seconds
+    cache[ prCacheKey(pullRequestInfo, pullRequestDetails) ] = {
+      timestamp: now,
+      packageInfo: packageInfo
+    };
+  }
+}
+
+function getInCache(pullRequestInfo, pullRequestDetails) {
+  const now = Math.floor(Date.now() / 1000);
+  const cached = cache[ prCacheKey(pullRequestInfo, pullRequestDetails) ];
+  if(cached) {
+    // more than 10s ago
+    const delayExhausted = (now - cached.timestamp) > 10;
+    console.log((now - cached.timestamp));
+    if(delayExhausted) {
+      cache[ prCacheKey(pullRequestInfo, pullRequestDetails) ] = null;
+      return null;
+    } else {
+      return cached.packageInfo;
+    }
+  } else {
+    return null;
+  }
+}
+
+// we use a cache to make sure we don't flood izuna server
+function getPackageInfo(pullRequestInfo, pullRequestDetails) {
+  const cached = getInCache(pullRequestInfo, pullRequestDetails);
+  if (cached) {
+    return Promise.resolve(cached);
+  } else {
+    const oldPackageInfo = fetchPackageInfo(pullRequestInfo, pullRequestDetails.targetOid);
+    const newPackageInfo = fetchPackageInfo(pullRequestInfo, pullRequestDetails.commitOids[0]);
+    return Promise.all([oldPackageInfo, newPackageInfo]);
+  }
+}
+
+
+function prCacheKey(pullRequestInfo, pullRequestDetails) {
+  return pullRequestInfo.user + '/' + pullRequestInfo.repo + '/' + pullRequestInfo.packageName + '/' + pullRequestInfo.pullRequest + '/' + pullRequestDetails.targetOid + '/' + pullRequestDetails.commitOids[0];
+}
+
+
+// return the url pathname if the current tab is loaded and is a github pull request page
+function githubPullRequestUrlPathName(tabId, changeInfo, tab) {
+  if( changeInfo &&
+      changeInfo.status &&
+      changeInfo.status === 'complete' &&
+      tab.active &&
+      tab.status === 'complete') {
+    const url = new URL(tab.url);
+    if(url.hostname === 'github.com') {
+      const pathAction = url.pathname.split('/')[3];
+      const prTab = url.pathname.split('/')[5];
+      if(pathAction === 'pull' && prTab === 'files') {
+        return url.pathname
+      }
+    }
+  }
+
+  return false;
 }
 
 /*
- * when browsing a pull request, we can fetch information related to the PR from the url.
- eg: https://github.com/matsumonkie/izuna-example/pull/7/files
+ * when browsing a pull request, we can fetch information related to the PR from the url pathname.
+ eg: /matsumonkie/izuna-example/pull/7/files
  gives us: the owner, the repo and the PR number
 */
-function getPullRequestInfo(tabs) {
-  const [user, repo, pull, pullRequest, ...tail] = tabs[0].url.slice("https://github.com/".length).split("/");
+function getPullRequestInfo(pathname) {
+  const [empty, user, repo, pull, pullRequest, ...tail] = pathname.split("/");
 
   // If a user has a repo with multiple package, I don't have any ways to know which package they want to load
   // for now, let's assume they only have one package with the same name as the repo

--- a/chrome-extension/contentScript.js
+++ b/chrome-extension/contentScript.js
@@ -1,37 +1,33 @@
-main();
+chrome.runtime.onMessage.addListener((payload, sender, sendResponse) => main(payload));
 
+function main (payload) {
+  console.debug(payload)
 
-function main () {
-  chrome.runtime.sendMessage({}, response => {
-    console.debug(response);
+  try {
+    const haskellDiffDoms = getAllHaskellDiffDom();
+    haskellDiffDoms.forEach(diffDom => {
+      const splitMode = isSplitMode(diffDom);
+      const filePath =  getFilePath(diffDom);
+      const moduleInfo = {
+        oldModuleInfo: payload.oldPackageInfo[filePath],
+        newModuleInfo: payload.newPackageInfo[filePath]
+      };
+      if(moduleInfo.oldModuleInfo || moduleInfo.newPackageInfo) {
+        const diffRowsDom = getDiffRowsDom(filePath, diffDom);
+        Array.from(diffRowsDom).forEach (diffRowDom => generateRow(filePath, moduleInfo, splitMode, diffRowDom));
+      }
+    });
+  } catch (error) {
+    console.error("izuna: Fatal error occurred, izuna will stop working on this page")
+    console.error("izuna: Try reloading your page")
+    console.error("izuna: Please report the error below to https://github.com/matsumonkie/izuna/issues")
+    console.error("izuna: " + error)
+    return;
+  }
 
-    try {
-      const haskellDiffDoms = getAllHaskellDiffDom();
-      haskellDiffDoms.forEach(diffDom => {
-        const splitMode = isSplitMode(diffDom);
-        const filePath =  getFilePath(diffDom);
-        const moduleInfo = {
-          oldModuleInfo: response.oldPackageInfo[filePath],
-          newModuleInfo: response.newPackageInfo[filePath]
-        };
-        if(moduleInfo.oldModuleInfo || moduleInfo.newPackageInfo) {
-          const diffRowsDom = getDiffRowsDom(filePath, diffDom);
-          Array.from(diffRowsDom).forEach (diffRowDom => generateRow(filePath, moduleInfo, splitMode, diffRowDom));
-        }
-      });
-    } catch (error) {
-      console.error("izuna: Fatal error occurred, izuna will stop working on this page")
-      console.error("izuna: Try reloading your page")
-      console.error("izuna: Please report the error below to https://github.com/matsumonkie/izuna/issues")
-      console.error("izuna: " + error)
-      return;
-    }
-
-    const tooltip = createPopper();
-    document.body.appendChild(tooltip);
-    mkNotificationEvents(tooltip);
-  });
-
+  const tooltip = createPopper();
+  document.body.appendChild(tooltip);
+  mkNotificationEvents(tooltip);
 }
 
 

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -8,7 +8,7 @@
   "description": "Better Haskell code review for Github!",
   "permissions": [ "tabs", "https://izuna-server.patchgirl.io/"],
   "background": {
-    "scripts": ["background.js"],
+    "scripts": [ "background.js" ],
     "persistent": false
   },
   "content_scripts": [


### PR DESCRIPTION
when on a PR, we can switch tabs (conversation, commits, checks and
files changed)
because GH uses a technology similar to turbolinks (where the whole
page isn't reloaded, only its content), izuna wasn't being run on tab
switch.

so we fix this by:
  - [x] listenning to the tab url changes
  - [x] using a cache to download the packages info only once every X seconds

Also, we used to send a dummy query from the content page to the
background page and wait for its response. Now we only send 1 message
from the background page to the content script!